### PR TITLE
Fix typo and Make the cnd links https

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="{{ "/css/font-awesome.min.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <script src="{{ "/js/jquery-1.12.0.min.js" | prepend: site.baseurl }}"></script>    
-  <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+  <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <link rel="shortcut icon" href="{{ site::baseurl }}/images/favicon.png" type="image/x-icon">
 </head>

--- a/docs/chapter02/3_1.md
+++ b/docs/chapter02/3_1.md
@@ -431,7 +431,7 @@ $$-\dfrac{1}{2}({\bf x}-{\pmb \mu})^T\Sigma^{-1}({\bf x}-{\pmb \mu})=-\dfrac{1}{
 - 따라서 이번에는 \\( {\bf x}\_b \\) 텀에 대해 각각의 계수를 모아본다. 
 - 따라서 마찬가지로 *completing the square* 를 사용하게 된다.
 
-$$-\dfrac{1}{2}{\bf x}_b^{T}\Lambda_{bb}{\bf x}_b + {\bf x}_b^T{\bf m} = -\dfrac{1}{2}({\bf x}_b-{\bf m})^T\Lambda_{bb}({\bf x}_b-\Lambda_{bb}^{-1}{\bf m}) + \dfrac{1}{2}{\bf m}^T\Lambda_{bb}^{-1}{\bf m} \qquad{(2.84)}$$
+$$-\dfrac{1}{2}{\bf x}_b^{T}\Lambda_{bb}{\bf x}_b + {\bf x}_b^T{\bf m} = -\dfrac{1}{2}({\bf x}_b-\Lambda_{bb}^{-1}{\bf m})^T\Lambda_{bb}({\bf x}_b-\Lambda_{bb}^{-1}{\bf m}) + \dfrac{1}{2}{\bf m}^T\Lambda_{bb}^{-1}{\bf m} \qquad{(2.84)}$$
 
 - 위의 식은 \\( {\bf x}\_b \\) 에 대해 완전 제곱식을 이용해서 전개한 식이다.
     - 완전 제곱식이란 말을 너무 오랜만에 들어서 기억이 안 날수도 있는데,


### PR DESCRIPTION
- 828ad5c631dcef22257804fbf86c9c8357fa5683 식 (2.84)의 첫번째 m term의 오타를 고쳤습니다.
- 8f5e7598eeda0544dc15fbdccb9e362e97190ae1 cdn link (bootstrap, mathjax) 를 https 링크로 바꿨습니다.